### PR TITLE
Create ASDF system definition for maxima-toi

### DIFF
--- a/maxima-toi.asd
+++ b/maxima-toi.asd
@@ -1,0 +1,26 @@
+;; ASDF system definition for maxima-toi
+;; cargo-culted from other ASDF files ...
+;; if anyone knows how to do this "right", I'll be glad to hear about it.
+;; Robert Dodier 2018-07-04
+
+(defclass toi-file (source-file)
+  ((type :initform "lisp")))
+
+(defmethod perform ((o load-source-op) (c toi-file))
+  (let ((source-file (first (input-files o c))))
+    (funcall (find-symbol "TOI-READ-ADD-TABLE" (find-package "MAXIMA")) source-file)))
+    
+(defmethod perform ((o load-op) (c toi-file))
+  (let ((source-file (first (input-files o c))))
+    (funcall (find-symbol "TOI-READ-ADD-TABLE" (find-package "MAXIMA")) source-file)))
+
+(defmethod perform ((o compile-op) (c toi-file))
+  (let ((source-file (first (input-files o c))))
+    (compile-file* source-file)))
+
+(defsystem maxima-toi
+  :components
+    ((:file "toi")
+     (:file "toi-support")
+     (:toi-file "toi-integral-table")))
+


### PR DESCRIPTION
This PR contains a new file, maxima-toi.asd, which is a system definition for ASDF. With this file, one can do this to load maxima-toi into Maxima:

````
:lisp (push "/path/to/maxima-toi/" asdf:*central-registry*)
:lisp (asdf:oos 'asdf:load-op :maxima-toi)
```

where /path/to/maxima-toi is the location in the local file system into which maxima-toi has been cloned.
NOTE: the path must be terminated by a trailing slash when you push it onto `asdf:*central-registry*`.

This assumes of course that ASDF is already loaded somehow.

maxima-toi.asd just loads the .lisp files and then calls `toi-read-add-table` to load the table.